### PR TITLE
Version parsing fix

### DIFF
--- a/src/main/java/com/redhat/quarkus/pmtools/extensionsgenerator/utils/VersionUtils.java
+++ b/src/main/java/com/redhat/quarkus/pmtools/extensionsgenerator/utils/VersionUtils.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 
 public class VersionUtils {
 
-    private static final Pattern pattern = Pattern.compile("^(\\d+\\.\\d+\\.\\d+\\.\\w+).*");
+    private static final Pattern pattern = Pattern.compile("^(\\d+\\.\\d+\\.\\d+.*).redhat.*");
 
     private static final Pattern mainVersionPattern = Pattern.compile("^(\\d+)\\..*");
 


### PR DESCRIPTION
Version parsing fix

.Final version suffix is not used with RHBQ 3.8.3, existing pattern reported the version as 3.8.3.redhat